### PR TITLE
Fix for Piexif Dump Issue and Enhanced Failed File Handling with Auto-Copy

### DIFF
--- a/src/auxFunctions.py
+++ b/src/auxFunctions.py
@@ -6,17 +6,30 @@ from fractions import Fraction
 
 
 # Credit: https://stackoverflow.com/questions/3173320/text-progress-bar-in-terminal-with-block-characters
-def progressBar(iterable, prefix = '', suffix = '', decimals = 1, length = 100, fill = '█', printEnd = "\r", upLines = 0):
+def progressBar(
+    iterable,
+    prefix="",
+    suffix="",
+    decimals=1,
+    length=100,
+    fill="█",
+    printEnd="\r",
+    upLines=0,
+):
     UP = "\x1B[" + str(upLines + 1) + "A"
 
     total = len(iterable)
-    # Progress Bar Printing Function
-    def printProgressBar (iteration):
-        percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
-        filledLength = int(length * iteration // total)
-        bar = fill * filledLength + '-' * (length - filledLength)
 
-        print(f'\r{prefix} |{bar}| {percent}% {suffix}', end = printEnd)
+    # Progress Bar Printing Function
+    def printProgressBar(iteration):
+        percent = ("{0:." + str(decimals) + "f}").format(
+            100 * (iteration / float(total))
+        )
+        filledLength = int(length * iteration // total)
+        bar = fill * filledLength + "-" * (length - filledLength)
+
+        print(f"\r{prefix} |{bar}| {percent}% {suffix}", end=printEnd)
+
     # Initial Call
     printProgressBar(0)
     # Update Progress Bar
@@ -26,6 +39,7 @@ def progressBar(iterable, prefix = '', suffix = '', decimals = 1, length = 100, 
         printProgressBar(i + 1)
     # Print New Line on Complete
     print()
+
 
 # Function to search media associated to the JSON
 def searchMedia(path, title, editedWord):
@@ -45,11 +59,33 @@ def searchMedia(path, title, editedWord):
         if os.path.exists(filepath):
             return filepath
 
+
 # Supress incompatible characters
 def fixTitle(title):
-    return str(title).replace("%", "").replace("<", "").replace(">", "").replace("=", "").replace(":", "").replace("?","").replace(
-        "¿", "").replace("*", "").replace("#", "").replace("&", "").replace("{", "").replace("}", "").replace("\\", "").replace(
-        "@", "").replace("!", "").replace("¿", "").replace("+", "").replace("|", "").replace("\"", "").replace("\'", "")
+    return (
+        str(title)
+        .replace("%", "")
+        .replace("<", "")
+        .replace(">", "")
+        .replace("=", "")
+        .replace(":", "")
+        .replace("?", "")
+        .replace("¿", "")
+        .replace("*", "")
+        .replace("#", "")
+        .replace("&", "")
+        .replace("{", "")
+        .replace("}", "")
+        .replace("\\", "")
+        .replace("@", "")
+        .replace("!", "")
+        .replace("¿", "")
+        .replace("+", "")
+        .replace("|", "")
+        .replace('"', "")
+        .replace("'", "")
+    )
+
 
 # Recursive function to search name if its repeated
 def checkIfSameName(title, titleFixed, matchedFiles, recursionTime):
@@ -60,10 +96,12 @@ def checkIfSameName(title, titleFixed, matchedFiles, recursionTime):
     else:
         return titleFixed
 
+
 def setFileCreationTime(filepath, timeStamp):
     date = datetime.fromtimestamp(timeStamp)
     modTime = time.mktime(date.timetuple())
     os.utime(filepath, (modTime, modTime))
+
 
 def to_deg(value, loc):
     """convert decimal coordinates into degrees, munutes and seconds tuple
@@ -92,14 +130,23 @@ def change_to_rational(number):
     f = Fraction(str(number))
     return (f.numerator, f.denominator)
 
+
 def set_geo_exif(exif_dict, lat, lng, altitude):
     lat_deg = to_deg(lat, ["S", "N"])
     lng_deg = to_deg(lng, ["W", "E"])
 
-    exiv_lat = (change_to_rational(lat_deg[0]), change_to_rational(lat_deg[1]), change_to_rational(lat_deg[2]))
-    exiv_lng = (change_to_rational(lng_deg[0]), change_to_rational(lng_deg[1]), change_to_rational(lng_deg[2]))
+    exiv_lat = (
+        change_to_rational(lat_deg[0]),
+        change_to_rational(lat_deg[1]),
+        change_to_rational(lat_deg[2]),
+    )
+    exiv_lng = (
+        change_to_rational(lng_deg[0]),
+        change_to_rational(lng_deg[1]),
+        change_to_rational(lng_deg[2]),
+    )
 
-    altitudeRef = 1 if altitude > 0 else 0 
+    altitudeRef = 1 if altitude > 0 else 0
 
     gps_ifd = {
         piexif.GPSIFD.GPSVersionID: (2, 0, 0, 0),
@@ -111,25 +158,43 @@ def set_geo_exif(exif_dict, lat, lng, altitude):
         piexif.GPSIFD.GPSLongitude: exiv_lng,
     }
 
-    exif_dict['GPS'] = gps_ifd
+    exif_dict["GPS"] = gps_ifd
+
 
 def set_date_exif(exif_dict, timestamp):
     dateTime = datetime.fromtimestamp(timestamp).strftime("%Y:%m:%d %H:%M:%S")
-    exif_dict['0th'][piexif.ImageIFD.DateTime] = dateTime
+    exif_dict["0th"][piexif.ImageIFD.DateTime] = dateTime
     exif_dict["0th"][piexif.ImageIFD.Orientation] = 1
-    exif_dict['Exif'][piexif.ExifIFD.DateTimeOriginal] = dateTime
-    exif_dict['Exif'][piexif.ExifIFD.DateTimeDigitized] = dateTime
+    exif_dict["Exif"][piexif.ExifIFD.DateTimeOriginal] = dateTime
+    exif_dict["Exif"][piexif.ExifIFD.DateTimeDigitized] = dateTime
+
 
 def adjust_exif(exif_info, metadata):
-    timeStamp = int(metadata['photoTakenTime']['timestamp'])
+    timeStamp = int(metadata["photoTakenTime"]["timestamp"])
 
-    exif_dict = piexif.load(exif_info)
+    try:
+        exif_dict = piexif.load(exif_info)
+    except Exception as e:
+        print(f"Error loading EXIF info: {e}. Starting with an empty EXIF.")
+        exif_dict = {
+            "0th": {},
+            "Exif": {},
+            "GPS": {},
+            "Interop": {},
+            "1st": {},
+            "thumbnail": None,
+        }
+
+    if 41729 in exif_dict["Exif"] and isinstance(exif_dict["Exif"][41729], int):
+        exif_dict["Exif"][41729] = str(exif_dict["Exif"][41729]).encode(
+            "utf-8"
+        )  # Convert integer to bytes.
 
     del exif_dict["thumbnail"]
 
-    lat = metadata['geoData']['latitude']
-    lng = metadata['geoData']['longitude']
-    altitude = metadata['geoData']['altitude']
+    lat = metadata["geoData"]["latitude"]
+    lng = metadata["geoData"]["longitude"]
+    altitude = metadata["geoData"]["altitude"]
 
     set_date_exif(exif_dict, timeStamp)
     set_geo_exif(exif_dict, lat, lng, altitude)


### PR DESCRIPTION
This PR addresses issues similar to [[Piexif issue #95](https://github.com/hMatoba/Piexif/issues/95)](https://github.com/hMatoba/Piexif/issues/95), where problems were encountered when dumping EXIF data with Piexif, particularly in scenarios with invalid image formats or missing metadata.

### Key Changes:
1. **Fix for Piexif Dump Issue**:
   - The error was linked to incorrect handling during EXIF data dumping. The root cause of the issue was related to incorrectly accessed or malformed data while using the Piexif library. I’ve made the necessary adjustments to prevent the `dump` operation from failing on unsupported file formats or corrupted metadata.

2. **Auto-Copy of All Failed Files**:
   - As an added feature, this update automatically copies all failed files (due to invalid formats, missing metadata, or other issues) into a dedicated `failed` subfolder within the output directory.
   - The folder structure inside the `failed` directory mirrors the source folder structure. This ensures that users can quickly locate and inspect any failed files, particularly useful for those dealing with large numbers of processed images.
   - Previously, there was no  copy function for failed files, which could make it difficult to track and resolve failures in massive image datasets.

### Motivation:
- The change ensures that invalid or problematic image files (whether caused by EXIF issues or unsupported formats) can be easily detected, organized, and reviewed, without cluttering the main output folder.
- Given the scale at which many users are processing images, providing a clean and structured approach to handling failures streamlines the debugging and review process, making it much easier to find and address problematic files.

### How to Test:
1. Process images with various supported and unsupported formats.
2. Confirm that all failed files due to any errors (e.g., EXIF dump issues, missing metadata) are copied to the `failed` subfolder.
3. Verify that the `failed` folder contains the same directory structure as the root folder for easy identification.
4. Ensure that files that pass through the process are saved correctly in the output directory.

Thanks for reviewing this PR, and I’m happy to address any feedback!