### PR TITLE
Added 'filename' to the list of possible titles.

### DIFF
--- a/src/auxFunctions.py
+++ b/src/auxFunctions.py
@@ -35,6 +35,7 @@ def searchMedia(path, title, editedWord):
 
     possible_titles = [
         title,
+        file_name,
         str(file_name + "-" + editedWord + "." + ext),
         str(file_name + "(1)." + ext),
     ]


### PR DESCRIPTION
While using the program it detected with ease the `.json` files, but not the pictures associated with it. I don't know if Google changed recently the names of the json files, but I got the following possible titles:
```python
[
'IMG20240722194746.jpg.supplemental-metadata',
'IMG20240722194746.jpg-edited..supplemental-metadata',
'IMG20240722194746.jpg(1)..supplemental-metadata'
]
```

So I added the `filename` directly because in this case, it was the correct file name "IMG20240722194746.jpg".